### PR TITLE
Adds support for Boolean types and support for '<>' operators

### DIFF
--- a/src/mongoParser/whereClause.js
+++ b/src/mongoParser/whereClause.js
@@ -37,6 +37,8 @@ function parseWhere(whereTree) {
     return whereTree.value.replace(/['"]+/g, "");
   case "Number":
     return +whereTree.value;
+  case "Boolean":
+    return whereTree.value.toLowerCase() === "true";
   default:
     throw new Error(`Unsupported expression type: ${whereTree.type}`);
   }
@@ -169,6 +171,7 @@ function getEqulityOperator(sqlOperator) {
     return "$lt";
   case "<=":
     return "$lte";
+  case "<>":
   case "!=":
     return "$ne";
   default:

--- a/src/mongoParser/whereClause.js
+++ b/src/mongoParser/whereClause.js
@@ -139,6 +139,7 @@ function handleComparisonOperator(whereTree) {
   case "<=":
   case ">":
   case ">=":
+  case "<>":
   case "!=":
     return {
       [whereTree.left.value]: {

--- a/test/lib/mongoParser/whereClause.spec.js
+++ b/test/lib/mongoParser/whereClause.spec.js
@@ -11,6 +11,16 @@ describe("parseWhere", () => {
     });
   });
 
+  describe("type is Boolean", () => {
+    it("should return a boolean", () => {
+      const whereTree = { type: "Boolean", value: "TRUE" };
+
+      const result = parseWhere(whereTree);
+
+      expect(result).toBe(true);
+    });
+  });
+
   describe("type is String", () => {
     it("should return a string", () => {
       const whereTree = { type: "String", value: "1337" };
@@ -258,6 +268,22 @@ describe("parseWhere", () => {
       });
     });
 
+    describe("operator is <>", () => {
+      it("should return a valid $ne object", () => {
+        const whereTree = {
+          type: "ComparisonBooleanPrimary",
+          left: { type: "Identifier", value: "city" },
+          operator: "<>",
+          right: { type: "String", value: ""Rio"" }
+        };
+        const expected = { city: { $ne: "Rio" } };
+
+        const result = parseWhere(whereTree);
+
+        expect(result).toEqual(expected);
+      });
+    });
+
     describe("operator is >", () => {
       it("should return a valid $gt object", () => {
         const whereTree = {
@@ -326,7 +352,7 @@ describe("parseWhere", () => {
       const whereTree = {
         type: "ComparisonBooleanPrimary",
         left: { type: "Identifier", value: "age" },
-        operator: "<>",
+        operator: "|",
         right: { type: "Number", value: "18" }
       };
 

--- a/test/lib/mongoParser/whereClause.spec.js
+++ b/test/lib/mongoParser/whereClause.spec.js
@@ -274,7 +274,7 @@ describe("parseWhere", () => {
           type: "ComparisonBooleanPrimary",
           left: { type: "Identifier", value: "city" },
           operator: "<>",
-          right: { type: "String", value: ""Rio"" }
+          right: { type: "String", value: "'Rio'" }
         };
         const expected = { city: { $ne: "Rio" } };
 


### PR DESCRIPTION
Two capabilities added in this PR:

1. Adds support for Boolean types: `getMongoQuery('someField = TRUE')` returns `{ someField: true }`
2. Adds support for `<>` operator:  `getMongoQuery('someField <> TRUE')` returns `{ someField: { '$ne': true } }`

This PR also includes test for the added capabilities.

Fixes #18