### PR TITLE
Add 'Null' support and adds same field support for AND queries

### DIFF
--- a/src/mongoParser/whereClause.js
+++ b/src/mongoParser/whereClause.js
@@ -37,6 +37,8 @@ function parseWhere(whereTree) {
     return whereTree.value.replace(/['"]+/g, "");
   case "Number":
     return +whereTree.value;
+  case "Boolean":
+    return whereTree.value.toLowerCase() === "true";
   default:
     throw new Error(`Unsupported expression type: ${whereTree.type}`);
   }
@@ -169,6 +171,7 @@ function getEqulityOperator(sqlOperator) {
     return "$lt";
   case "<=":
     return "$lte";
+  case "<>":
   case "!=":
     return "$ne";
   default:

--- a/src/mongoParser/whereClause.js
+++ b/src/mongoParser/whereClause.js
@@ -139,6 +139,7 @@ function handleComparisonOperator(whereTree) {
   case "<=":
   case ">":
   case ">=":
+  case "<>":
   case "!=":
     return {
       [whereTree.left.value]: {

--- a/src/mongoParser/whereClause.js
+++ b/src/mongoParser/whereClause.js
@@ -39,17 +39,25 @@ function parseWhere(whereTree) {
     return +whereTree.value;
   case "Boolean":
     return whereTree.value.toLowerCase() === "true";
+  case "Null":
+    return null;
   default:
     throw new Error(`Unsupported expression type: ${whereTree.type}`);
   }
 }
 
 function handleAndExpression(whereTree) {
-  return Object.assign(
-    {},
-    parseWhere(whereTree.left),
-    parseWhere(whereTree.right)
-  );
+  const left = parseWhere(whereTree.left);
+  const right = parseWhere(whereTree.right);
+
+  if (Object.keys(left)[0] === "$and") {
+    left["$and"].push(right);
+    return left;
+  }
+
+  return {
+    $and: [left, right]
+  };
 }
 
 function handleOrExpression(whereTree) {

--- a/test/lib/mongoParser/whereClause.spec.js
+++ b/test/lib/mongoParser/whereClause.spec.js
@@ -11,6 +11,16 @@ describe("parseWhere", () => {
     });
   });
 
+  describe("type is Boolean", () => {
+    it("should return a boolean", () => {
+      const whereTree = { type: "Boolean", value: "TRUE" };
+
+      const result = parseWhere(whereTree);
+
+      expect(result).toBe(true);
+    });
+  });
+
   describe("type is String", () => {
     it("should return a string", () => {
       const whereTree = { type: "String", value: "1337" };
@@ -258,6 +268,22 @@ describe("parseWhere", () => {
       });
     });
 
+    describe("operator is <>", () => {
+      it("should return a valid $ne object", () => {
+        const whereTree = {
+          type: "ComparisonBooleanPrimary",
+          left: { type: "Identifier", value: "city" },
+          operator: "<>",
+          right: { type: "String", value: ""Rio"" }
+        };
+        const expected = { city: { $ne: "Rio" } };
+
+        const result = parseWhere(whereTree);
+
+        expect(result).toEqual(expected);
+      });
+    });
+
     describe("operator is >", () => {
       it("should return a valid $gt object", () => {
         const whereTree = {
@@ -326,7 +352,7 @@ describe("parseWhere", () => {
       const whereTree = {
         type: "ComparisonBooleanPrimary",
         left: { type: "Identifier", value: "age" },
-        operator: "<>",
+        operator: "|",
         right: { type: "Number", value: "18" }
       };
 

--- a/test/lib/mongoParser/whereClause.spec.js
+++ b/test/lib/mongoParser/whereClause.spec.js
@@ -21,6 +21,16 @@ describe("parseWhere", () => {
     });
   });
 
+  describe("type is Null", () => {
+    it("should return null", () => {
+      const whereTree = { type: "Null", value: "null" };
+
+      const result = parseWhere(whereTree);
+
+      expect(result).toBe(null);
+    });
+  });
+
   describe("type is String", () => {
     it("should return a string", () => {
       const whereTree = { type: "String", value: "1337" };

--- a/test/lib/mongoParser/whereClause.spec.js
+++ b/test/lib/mongoParser/whereClause.spec.js
@@ -133,7 +133,7 @@ describe("parseWhere", () => {
   });
 
   describe("type is AndExpression (AND)", () => {
-    it("should return a valid $or object", () => {
+    it("should return a valid $and object", () => {
       const whereTree = {
         type: "AndExpression",
         operator: "AND",
@@ -150,7 +150,7 @@ describe("parseWhere", () => {
           right: { type: "Number", value: "42" }
         }
       };
-      const expected = { city: "Rio", life: 42 };
+      const expected = { '$and': [ { city: 'Rio' }, { life: 42 } ] };
 
       const result = parseWhere(whereTree);
 

--- a/test/lib/mongoParser/whereClause.spec.js
+++ b/test/lib/mongoParser/whereClause.spec.js
@@ -274,7 +274,7 @@ describe("parseWhere", () => {
           type: "ComparisonBooleanPrimary",
           left: { type: "Identifier", value: "city" },
           operator: "<>",
-          right: { type: "String", value: ""Rio"" }
+          right: { type: "String", value: "'Rio'" }
         };
         const expected = { city: { $ne: "Rio" } };
 


### PR DESCRIPTION
Adds additional support for the AST type of 'Null' for parsing.
 - Fixes #19 

Also, this adds support for `where` clauses with multiple `AND` expressions on the same field.
See this [link](https://docs.mongodb.com/manual/reference/operator/query/and/#and-queries-with-multiple-expressions-specifying-the-same-field) for a description of how it should look.
 - Fixes #20 
